### PR TITLE
Rework how command parsing/locating works

### DIFF
--- a/handler/chat.py
+++ b/handler/chat.py
@@ -81,18 +81,13 @@ class Help(object):
         return {'commands': ('help',)}
 
     def help_command(self, context, text, dispatcher):
-        try:
-            # try as-is
-            handler = dispatcher.commands[text]
-            # add the leader
-            text = f'{dispatcher.LEADER}{text}'
-        except KeyError:
-            try:
-                # try skipping the leader in case they did `.help .foo`
-                handler = dispatcher.commands[text[len(dispatcher.LEADER) :]]
-            except KeyError:
-                context.say(f'Sorry `{text}` is not a recognized command')
-        context.say(f'Help for `{text}`\n```{handler.__doc__}```')
+        if text.startswith(dispatcher.LEADER):
+            text = text[len(dispatcher.LEADER) :]
+        _, handler, _, _ = dispatcher.find_handler(text)
+        if handler:
+            context.say(f'Help for `{text}`\n```{handler.__doc__}```')
+        else:
+            context.say(f'Sorry `{text}` is not a recognized command')
 
     def _summarize_command(self, command, handler, dispatcher):
         try:

--- a/slacker/listeners.py
+++ b/slacker/listeners.py
@@ -318,16 +318,7 @@ class SlackListener(object):
             )
         else:
             if text.startswith(self.bot_mention):
-                # TODO: this is way to messay, refactor, clean up and test
-                # independantly
                 text = text.replace(f'{self.bot_mention} ', '')
-                text = text.lstrip()
-                try:
-                    command, text = text.split(' ', 1)
-                except ValueError:
-                    command = text
-                    text = ''
-                text = text.lstrip()
                 self.dispatcher.command(
                     context=SlackContext(
                         app=self.app,
@@ -336,7 +327,6 @@ class SlackListener(object):
                         timestamp=ts,
                         bot_user_id=bot_user_id,
                     ),
-                    command=command,
                     text=text,
                     sender=sender,
                     sender_type=sender_type,
@@ -346,13 +336,7 @@ class SlackListener(object):
                 text.startswith(self.dispatcher.LEADER)
                 and text[len(self.dispatcher.LEADER)] != ' '
             ):
-                text = text[len(self.dispatcher.LEADER) :]
-                try:
-                    command, text = text.split(' ', 1)
-                except ValueError:
-                    command = text
-                    text = ''
-                text = text.lstrip()
+                text = text.replace(self.dispatcher.LEADER, '')
                 self.dispatcher.command(
                     context=SlackContext(
                         app=self.app,
@@ -361,7 +345,6 @@ class SlackListener(object):
                         timestamp=ts,
                         bot_user_id=bot_user_id,
                     ),
-                    command=command,
                     text=text,
                     sender=sender,
                     sender_type=sender_type,


### PR DESCRIPTION
Break text up into pieces w/`split`. Command matching done with tuples so it's a straight hash lookup. Rebuild `command` & `text` from pieces with `' '.join()` so that whitespace is clean & normalized for everything. Should be cleaner and more efficient and importantly lives in a single place and used by everything. Easier for everyone else to deal with as they won't have to think about whitespace. 