### PR TITLE
Db stuffs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pytz==2021.3
 regex==2021.10.8
 requests==2.26.0
 six==1.16.0
-slack-bolt==1.9.2
+slack-bolt==1.10.0
 slack-sdk==3.11.2
 sqlparse==0.4.2
 tqdm==4.62.3

--- a/simone/dispatcher.py
+++ b/simone/dispatcher.py
@@ -80,6 +80,7 @@ class Dispatcher(object):
             settings, 'SLACK_TOKEN_VERIFICATION', False
         )
         app = App(
+            name='simone',
             token=environ["SLACK_BOT_TOKEN"],
             signing_secret=environ["SLACK_SIGNING_SECRET"],
             token_verification_enabled=token_verification,

--- a/simone/settings/dev.py
+++ b/simone/settings/dev.py
@@ -1,3 +1,4 @@
+from os import environ
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -7,12 +8,26 @@ DEBUG = True
 
 CRON_ENABLED = False
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db' / 'db.sqlite3',
+
+if 'SIMONE_DB_NAME' in environ:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'mysql.connector.django',
+            'NAME': environ['SIMONE_DB_NAME'],
+            'USER': environ['SIMONE_DB_USER'],
+            'PASSWORD': environ['SIMONE_DB_PASSWORD'],
+            'HOST': environ['SIMONE_DB_HOST'],
+            'PORT': environ.get('SIMONE_DB_PORT', '3306'),
+            'CONN_MAX_AGE': 300,
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db' / 'db.sqlite3',
+        }
+    }
 
 LOGGING = {
     'version': 1,

--- a/slacker/listeners.py
+++ b/slacker/listeners.py
@@ -1,10 +1,7 @@
-from django.conf import settings
 from django.http import HttpRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.urls import path
 from logging import getLogger
-from os import environ
-from slack_bolt import App
 from slack_bolt.adapter.django import SlackRequestHandler
 import re
 
@@ -81,20 +78,11 @@ class SlackListener(object):
 
     log = getLogger('SlackListener')
 
-    def __init__(self, dispatcher, app=None):
+    def __init__(self, dispatcher, app):
         self.log.info('__init__: dispatcher=%s, app=%s', dispatcher, app)
         self.dispatcher = dispatcher
-
-        if app is None:
-            token_verification = getattr(
-                settings, 'SLACK_TOKEN_VERIFICATION', False
-            )
-            app = App(
-                token=environ["SLACK_BOT_TOKEN"],
-                signing_secret=environ["SLACK_SIGNING_SECRET"],
-                token_verification_enabled=token_verification,
-            )
         self.app = app
+
         self._auth_info = None
         self._bot_mention = None
 

--- a/slacker/tests.py
+++ b/slacker/tests.py
@@ -968,7 +968,8 @@ class TestSlackListener(TestCase):
         )
 
     def test_channel_rename(self):
-        listener = SlackListener(dispatcher=None, app=None)
+        app = DummyApp()
+        listener = SlackListener(dispatcher=None, app=app)
 
         # create a channel we've never seen before
         event = {


### PR DESCRIPTION
#### Support mysql db in dev when env vars are defined

#### Rework cron validation to avoid chicken-n-egg during bootstraping

#### Provide executor to slack_bolt app, don't re-submit

After some digging into the slack_bolt code it became evident that it's already submitting everything into a ThreadPoolExecutor so we don't need to do that ourselves. This reworks things to provide a custom executor with our names and size rather than let it create its own. It also adapts cron to handle the change. Much cleaner