### PR TITLE
Update django to 4.0.7 b/c CE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.0.6
+Django==4.0.7
 PyMeeus==0.5.11
 asgiref==3.5.2
 certifi==2021.10.8


### PR DESCRIPTION
```
django.db.utils.ProgrammingError: (-1, "Character set 'utf8' unsupported", None)
```

/cc https://github.com/ross/simone/pull/45 which pulled in a busted state w/mysql-connector
/cc https://github.com/ross/simone/pull/46 where ^ was reverted
/cc https://github.com/ross/simone/pull/44 which also pulled in a busted state w/mysql-connector so can't be used